### PR TITLE
Adding background permission into manifest.json file

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -54,6 +54,7 @@
         }
     },
     "permissions": [
+        "background",
         "tabs",
         "tts",
         "storage",


### PR DESCRIPTION
As the Chrome's documentation reads:

> If you need the browser to start up early—so you can display notifications, for example—then you might also want to specify the "background" permission.

So we need to add **background** into the **permissions** block of the _manifest.json_ file.
